### PR TITLE
126 prep code for 2.1.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.1.0
 commit = False
 tag = False
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -18,6 +18,8 @@ jobs:
             anki-version: "23.12.1"
           - python-version: "3.9"
             anki-version: "25.02"
+          - python-version: "3.9"
+            anki-version: "25.9.5"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/doc/ankiweb_description.md
+++ b/doc/ankiweb_description.md
@@ -1,4 +1,4 @@
-**Version - 2.0.0**
+**Version - 2.1.0**
 
 This add-on for Anki allows you to efficiently gather verb and adjective notes from your regular study decks and use them to generate decks aimed at practicing and studying various conjugations.
 
@@ -54,7 +54,7 @@ If you find any errors, please reach out to me so that they can be corrected!
 
 ## Release Notes
 
-Please see the [Release Notes in GitHub](https://github.com/njimse/anki-jpn-conjugations/blob/v2.0.0/doc/release_notes.md) for details on changes in this version as well as previous versions.
+Please see the [Release Notes in GitHub](https://github.com/njimse/anki-jpn-conjugations/blob/v2.1.0/doc/release_notes.md) for details on changes in this version as well as previous versions.
 
 
 ## Attribution

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 2.1.0
+
+* Added support for causative form
+* Added support for causative-passive form
+
 ## 2.0.0
 
 * Added support for passive form

--- a/japanese_conjugation/manifest.json
+++ b/japanese_conjugation/manifest.json
@@ -3,5 +3,5 @@
     "name": "Japanese Conjugation",
     "mod": "2026-07-04",
     "min_point_version": 49,
-    "max_point_version": 250902
+    "max_point_version": 250905
 }

--- a/japanese_conjugation/manifest.json
+++ b/japanese_conjugation/manifest.json
@@ -1,7 +1,7 @@
 {
     "package": "japanese_conjugation",
     "name": "Japanese Conjugation",
-    "mod": "2026-04-12",
+    "mod": "2026-07-04",
     "min_point_version": 49,
     "max_point_version": 250902
 }

--- a/japanese_conjugation/manifest.json
+++ b/japanese_conjugation/manifest.json
@@ -3,5 +3,5 @@
     "name": "Japanese Conjugation",
     "mod": "2026-07-04",
     "min_point_version": 49,
-    "max_point_version": 250905
+    "max_point_version": 260500
 }

--- a/japanese_conjugation/version.py
+++ b/japanese_conjugation/version.py
@@ -1,2 +1,2 @@
 """Version information"""
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 name = "japanese-conjugation"
 description = "This is a set of tooling to allow for generating anki cards for learning/practicing Japanese"
-version = "2.0.0"
+version = "2.1.0"
 requires-python = ">=3.8,<3.10"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
## Summary
Prepares the v2.1.0 release (closes #126). Release-prep only — no functional/conjugation code is touched.

- **Version bump 2.0.0 → 2.1.0** across every tracked location:
  - `.bumpversion.cfg` (`current_version`)
  - `japanese_conjugation/version.py`
  - `pyproject.toml`
  - `doc/ankiweb_description.md` (version header + release-notes tag URL → `v2.1.0`)
- **Release notes**: added a `2.1.0` section to `doc/release_notes.md` covering the two features merged since 2.0.0:
  - Causative form (#122)
  - Causative-passive form (#124)
- **Manifest**: refreshed `mod` date to `2026-07-04`.

## Supported Anki versions — raised
- `manifest.json` `max_point_version` raised **250902 → 260500** (declares support up to Anki **26.05**, the latest desktop release). `min_point_version` (49) is unchanged.
- Added **Anki 25.9.5** to the unit-test matrix in `.github/workflows/unittests.yml` (Python 3.9). The full suite (1562 tests) passes locally against 25.9.5.

### Note on the testing gap
Automated coverage tops out at **25.9.5** because that is the newest `anki` package available on PyPI (26.05's library isn't published there, so it can't be `pip install`-ed in CI). The `260500` bound therefore reflects manual verification against the 26.05 desktop app — consistent with the manifest previously being set ahead of the CI matrix (it was `250902` while CI only reached `25.02`).

## Other notes
- `japanese_conjugation.ankiaddon/` is an untracked local build-artifact directory and was intentionally not modified.
- The new conjugation features don't touch any Anki API surface; the version-range change reflects verified/declared compatibility, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
